### PR TITLE
Fix some problems in docker

### DIFF
--- a/dataframe_image/_screenshot.py
+++ b/dataframe_image/_screenshot.py
@@ -98,7 +98,8 @@ class Screenshot:
             args = [
                 "--enable-logging",
                 "--disable-gpu",
-                "--headless"
+                "--headless",
+                "--no-sandbox"
                 ]
 
             if self.ss_width and self.ss_height:


### PR DESCRIPTION
Sandboxing  For security reasons, Google Chrome is unable to provide sandboxing when it is running in the container-based environment. To use Chrome in the container-based environment, pass the --no-sandbox flag to the chrome executable