### PR TITLE
Added  '--crash-dumps-dir=/tmp' to chrome args to prevent the org.chromium.crashpad errors

### DIFF
--- a/dataframe_image/_browser_pdf.py
+++ b/dataframe_image/_browser_pdf.py
@@ -72,7 +72,8 @@ def launch_chrome():
         '--headless',
         '--disable-gpu', 
         '--run-all-compositor-stages-before-draw',
-        '--remote-debugging-port=9222'
+        '--remote-debugging-port=9222',
+        '--crash-dumps-dir=/tmp'
     ]
     p = Popen(args=args)
     return p

--- a/dataframe_image/_screenshot.py
+++ b/dataframe_image/_screenshot.py
@@ -98,7 +98,9 @@ class Screenshot:
             args = [
                 "--enable-logging",
                 "--disable-gpu",
-                "--headless"
+                "--headless",
+                "--crash-dumps-dir=/tmp"
+
                 ]
 
             if self.ss_width and self.ss_height:


### PR DESCRIPTION
See https://github.com/dexplo/dataframe_image/issues/18 

Cross references: 
https://stackoverflow.com/questions/49103799/running-chrome-in-headless-mode
