### PR TITLE
Add lxml to dependencies

### DIFF
--- a/dataframe_image/_matplotlib_table.py
+++ b/dataframe_image/_matplotlib_table.py
@@ -2,6 +2,7 @@ import base64
 import io
 import textwrap
 
+import lxml
 import numpy as np
 import pandas as pd
 from bs4 import BeautifulSoup


### PR DESCRIPTION
#41 : as the dependencies for this package are found by setuptools.find_packages(), we need to make lxml an import for it to be a dependency.