### PR TITLE
[BUGFIX]: screenshot: Avoid holding the image resource.

### DIFF
--- a/dataframe_image/_screenshot.py
+++ b/dataframe_image/_screenshot.py
@@ -112,26 +112,25 @@ class Screenshot:
         with open(temp_html, "w", encoding="utf-8") as f:
             f.write(self.html)
 
-        with open(temp_img, "wb") as f:
-            args = [
-                "--enable-logging",
-                "--disable-gpu",
-                "--headless",
-                "--no-sandbox",
-                "--crash-dumps-dir=/tmp",
-                f"--force-device-scale-factor={self.device_scale_factor}",
-            ]
+        args = [
+            "--enable-logging",
+            "--disable-gpu",
+            "--headless",
+            "--no-sandbox",
+            "--crash-dumps-dir=/tmp",
+            f"--force-device-scale-factor={self.device_scale_factor}",
+        ]
 
-            if self.ss_width and self.ss_height:
-                args.append(f"--window-size={self.ss_width},{self.ss_height}")
+        if self.ss_width and self.ss_height:
+            args.append(f"--window-size={self.ss_width},{self.ss_height}")
 
-            args += [
-                "--hide-scrollbars",
-                f"--screenshot={str(temp_img)}",
-                str(temp_html),
-            ]
+        args += [
+            "--hide-scrollbars",
+            f"--screenshot={str(temp_img)}",
+            str(temp_html),
+        ]
 
-            subprocess.run(executable=self.chrome_path, args=args)
+        subprocess.run(executable=self.chrome_path, args=args)
 
         with open(temp_img, "rb") as f:
             img_bytes = f.read()


### PR DESCRIPTION
Since the image is already open by the screenshot function, chrome can't write to that file and throw the exception, Failed to write file <file_name>
The process cannot access the file
because it is being used by another process.

Signed-off-by: Itamar Shalev <itamar1111111@gmail.com>