### PR TITLE
allow matplotlib color format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__/
 .DS_store
+.eggs/
+.idea/
 .ipynb_checkpoints/
 dataframe_image.egg-info/
 dist/
@@ -13,4 +15,5 @@ __init__.pyc
 /tests/**/*.png
 /tests/**/*.md
 /tests/**/*.gif
+/tests/**/*.html
 tests/notebooks/Short_dataframe_image.ipynb

--- a/dataframe_image/_matplotlib_table.py
+++ b/dataframe_image/_matplotlib_table.py
@@ -76,10 +76,11 @@ class TableMaker:
 
         def get_property(class_name, property_name):
             for rule in sheet:
-                if class_name in rule.selectorText:
-                    for property in rule.style:
-                        if property.name == property_name:
-                            return property.value
+                selectors = rule.selectorText.replace(" ", "").split(",")
+                if class_name in selectors:
+                    for style_property in rule.style:
+                        if style_property.name == property_name:
+                            return style_property.value
         def parse_row(row):
             values = []
             rowspan_dict = {}

--- a/dataframe_image/_matplotlib_table.py
+++ b/dataframe_image/_matplotlib_table.py
@@ -2,6 +2,7 @@ import base64
 import io
 import textwrap
 
+import cssutils
 import numpy as np
 import pandas as pd
 from bs4 import BeautifulSoup
@@ -47,7 +48,7 @@ class TableMaker:
                     cur_col_loc = 0
                     for _ in range(val[-1]):
                         cur_col_loc += 1
-                        new_row.append(val[:3])
+                        new_row.append(val[:5])
                     if val[-2] == 1:
                         del rowspan[col_loc]
                     col_loc += cur_col_loc
@@ -57,7 +58,7 @@ class TableMaker:
                         rowspan[col_loc] = val
                     col_loc += val[-1]  # usually 1
                     for _ in range(val[-1]):
-                        new_row.append(val[:3])
+                        new_row.append(val[:5])
                     j += 1
             new_rows.append(new_row)
         return new_rows, num_header_rows
@@ -72,6 +73,13 @@ class TableMaker:
                     return val
 
     def parse_into_rows(self, html):
+
+        def get_property(class_name, property_name):
+            for rule in sheet:
+                if class_name in rule.selectorText:
+                    for property in rule.style:
+                        if property.name == property_name:
+                            return property.value
         def parse_row(row):
             values = []
             rowspan_dict = {}
@@ -83,10 +91,14 @@ class TableMaker:
                 rowspan = int(el.attrs.get("rowspan", 1))
                 text_align = self.get_text_align(el) or row_align
                 text = el.get_text()
-                values.append([text, bold, text_align, rowspan, colspan])
+                if "id" in el.attrs:
+                    values.append([text, bold, text_align, get_property("#" + el.attrs["id"], "background-color"), get_property("#" + el.attrs["id"], "color"), rowspan, colspan])
+                else:
+                    values.append([text, bold, text_align, "#ffffff", "#000000", rowspan, colspan])
             return values
 
         soup = BeautifulSoup(html, features="lxml")
+        sheet = cssutils.parseString(soup.find('style').text)
         # get number of columns from first row
         # num_cols = sum(int(el.get('colspan', 1)) for el in soup.find('tr').find_all(['td', 'th']))
         thead = soup.find("thead")
@@ -210,6 +222,8 @@ class TableMaker:
                 text = val[0]
                 weight = "bold" if val[1] else None
                 ha = val[2] or header_text_align[j] or "right"
+                fg = val[4] if val[4] else "#000000"
+                bg = val[3] if val[3] else "#ffffff"
 
                 if ha == "right":
                     x += xd
@@ -223,6 +237,8 @@ class TableMaker:
                     ha=ha,
                     va="center",
                     weight=weight,
+                    color=fg,
+                    backgroundcolor=bg
                 )
                 if ha == "left":
                     x += xd

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setuptools.setup(
         "beautifulsoup4",
         "packaging",
         "mistune",
+        "lxml",
+        "cssutils",
     ],
     include_package_data=True,
     entry_points={

--- a/tests/test_df_image.py
+++ b/tests/test_df_image.py
@@ -22,6 +22,11 @@ class TestImage:
             "tests/test_output/covid19_styled.png"
         )
 
+    def test_styled_matplotlib(self):
+        df.tail(10).style.background_gradient().export_png(
+            "tests/test_output/covid19_styled_matplotlib.png", table_conversion="matplotlib"
+        )
+
     @pytest.mark.parametrize('dpi', test_dpi_values)
     def test_styled_changed_dpi(self, dpi):
         df.tail(10).style.background_gradient().export_png(


### PR DESCRIPTION
This change reads the style data from the HTML from pandas to attempt to find background and foreground colors for the cell text.  If no color data is found it defaults to #000000 foreground and #FFFFFF background.