### PR TITLE
Added if max_rows == -1

### DIFF
--- a/dataframe_image/_pandas_accessor.py
+++ b/dataframe_image/_pandas_accessor.py
@@ -107,7 +107,10 @@ def _export(obj, filename, fontsize, max_rows, max_cols, table_conversion, chrom
                 "and `max_cols` parameters"
             )
         raise ValueError(error_msg)
-
+        
+    if max_rows == -1:
+        max_rows = None
+        
     if max_cols == -1:
         max_cols = None
 


### PR DESCRIPTION
When exporting a pandas dataframe with table_conversion set to 'matplotlib' and max_rows set to -1, it causes an issue where the last row is truncated. To fix this issue, add code for max_rows along with max_cols.