### PR TITLE
Fix Python Future Warning

### DIFF
--- a/dataframe_image/converter/matplotlib_table.py
+++ b/dataframe_image/converter/matplotlib_table.py
@@ -144,7 +144,7 @@ class MatplotlibTableConverter:
             for row in tbody.findall(".//tr"):
                 rows.append(parse_row(row))
 
-        if not thead and not tbody:
+        if thead is None and tbody is None:
             for row in tree.findall(".//tr"):
                 rows.append(parse_row(row))
 


### PR DESCRIPTION
FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
 `if not thead and not tbody:`