### PR TITLE
Fix Selenium screenshot cropping issue by retrying with larger height

### DIFF
--- a/dataframe_image/converter/browser/selenium_converter.py
+++ b/dataframe_image/converter/browser/selenium_converter.py
@@ -54,6 +54,13 @@ class SeleniumConverter(BrowserConverter):
 
             # temp_img will be deleted after context exit
             img = Image.open(temp_img)
+            
+            # Retry with larger height if the first screenshot is too short
+            if img.height < required_height:
+                shortfall = required_height - img.height +200
+                driver.set_window_size(required_width + 150,  required_height + 90 + shortfall)
+                driver.save_screenshot(str(temp_img))
+                img = Image.open(temp_img)
         try:
             temp_dir_obj.cleanup()
         except OSError:


### PR DESCRIPTION
In some environments, the hardcoded `+90` height buffer used in `set_window_size()` is insufficient to capture the entire table, resulting in the bottom portion of the image being cut off.

This PR adds a simple retry mechanism:
- It first takes a screenshot using the standard height buffer;
- If the captured image height is still smaller than the required table height, it increases the height and retries once.